### PR TITLE
ci: harden CI (least-privilege, concurrency, timeout, SHA-pinned actions) + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot keeps dependencies current by opening pull requests when updates
+# are available. Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # GitHub Actions used in .github/workflows. Dependabot bumps the pinned commit
+  # SHA *and* the trailing "# vX.Y.Z" comment together, so SHA-pinning stays
+  # secure without going stale. (directory "/" means the .github/workflows tree.)
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      # Bundle all action updates into one PR instead of one per action.
+      actions:
+        patterns: ["*"]
+
+  # npm dev dependencies (eslint, globals, vitest). The extension itself ships
+  # no runtime npm packages, so these are tooling-only.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    groups:
+      dev-dependencies:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,30 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: this workflow only reads the repo to run checks, so the
+# automatically-provided GITHUB_TOKEN gets read-only scope. Nothing here writes
+# back to the repository, comments, or releases.
+permissions:
+  contents: read
+
+# If new commits arrive on the same branch/PR while a run is in flight, cancel
+# the stale run instead of queuing both — saves minutes and gives faster feedback.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    # Hard cap so a hung step (e.g. a stuck network install) can't burn the
+    # 6-hour default. This job normally finishes in well under a minute.
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Actions are pinned to a full-length commit SHA (immutable) with the
+      # human-readable version in a trailing comment. Dependabot keeps both in
+      # sync. See .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## What & why

Brings the CI workflow up to production-grade and adds automated dependency updates. **No extension code or tests change**, the checks themselves (`npm ci` / `lint` / `validate:json` / `test`) are byte-identical, so runtime behavior and the test suite are unaffected.

## Changes

### `.github/workflows/ci.yml` — hardening
- **Least privilege**: `permissions: contents: read` — the auto-provided `GITHUB_TOKEN` gets read-only scope (this workflow only reads the repo to run checks).
- **Concurrency**: `cancel-in-progress` on `${{ github.workflow }}-${{ github.ref }}` — a new push cancels the stale run instead of queuing both.
- **Timeout**: `timeout-minutes: 10` — hard cap vs. the 6-hour default.
- **SHA-pinned actions** (supply-chain safety): `actions/checkout` → `de0fac2…` (v6.0.2) and `actions/setup-node` → `48b55a0…` (v6.4.0), pinned to full commit SHAs with the version in a trailing comment. Also bumps both from v4 → v6.

### `.github/dependabot.yml` — new
- **`github-actions`** (weekly): keeps the pinned SHAs fresh — Dependabot bumps the commit SHA *and* the `# vX.Y.Z` comment together, so pinning stays secure without going stale.
- **`npm`** (weekly): keeps dev tooling (eslint, globals, vitest) current.
- Both grouped so related bumps arrive as a single PR.

## Regression check

Only CI infrastructure changed; no extension source touched. Verified locally:
- `npm run lint` ✅
- `npm run validate:json` ✅ (4/4 JSON files)
- `npm test` ✅ (19/19)

CI on this PR re-runs the same checks on a clean runner.

## Context

This is the code half of the production-grade CI work. `main` is already protected by a branch ruleset (require a PR + the `check` status check, block force pushes / deletions, 0 required approvals).
